### PR TITLE
fix to expired test card data

### DIFF
--- a/tasks/build_event.js
+++ b/tasks/build_event.js
@@ -11,7 +11,7 @@ module.exports = function(grunt) {
     getToken({
       "number": "4242424242424242",
       "exp_month": 12,
-      "exp_year": 2017,
+      "exp_year": 2020,
       "cvc": "123"
     },function(err, token){
       fs.writeFile("event.json", JSON.stringify({


### PR DESCRIPTION
When running the grunt run command Stripe returns an error due to the expired test credit card used for the token.